### PR TITLE
add 2021 forum info

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,6 +2,13 @@
 layout: default
 ---
 
+# 2021 IT 4 Social Economy Forum
+**Save the date!!** 
+We will meet online on **April 6th and 7th** from 9:00 to 13:00
+
+<button>[Read more](https://community.coopdevs.org/t/2021-it-4-social-economy-forum/1155)</button>
+
+
 ## A network of IT cooperatives
 
 Actors of the Social Economy need IT Tools to realize their missions. From share-management in an energy cooperative over member shift systems in cooperative supermarkets to management tools for shared housing initiatives. Luckily, a variety of IT cooperatives exists that build these tools. 

--- a/index.md
+++ b/index.md
@@ -77,10 +77,6 @@ We're working to creat a shared platform for functional documentation on the too
     * Implement an API for registration of new members
     * Generalize cooperative supermarket modules
     * Make it Spain-compatible
-    
-## On the horizon for 2021
-
-In February 2021 we'll organise our next get together. We plan to exchange views on the long term vision of our tools, share with each other the features we hear and think could benefit the actors we support, and share the work according to the capacity and financial resources at hand. Also, we hope to write some code and documentation together!
 
 ## Join us! 
 


### PR DESCRIPTION
Add 2021 forum info at the top of the website

![Screenshot_2021-01-19 2021 IT 4 Social Economy Forum](https://user-images.githubusercontent.com/2297137/105044093-9d784100-5a66-11eb-995b-1105d4392763.png)

@robinkeunen can you merge that? Also can yo give me permission to edit this repo? 
